### PR TITLE
update: image snapshots with utils-linux downgraded. #13

### DIFF
--- a/infra/cluster/dev/kube.tf
+++ b/infra/cluster/dev/kube.tf
@@ -859,8 +859,8 @@ module "kube-hetzner" {
   # MicroOS snapshot IDs to be used. Per default empty, the most recent image created using createkh will be used.
   # We recommend the default, but if you want to use specific IDs you can.
   # You can fetch the ids with the hcloud cli by running the "hcloud image list --selector 'microos-snapshot=yes'" command.
-  microos_x86_snapshot_id = "242591242"
-  microos_arm_snapshot_id = "242591241"
+  microos_x86_snapshot_id = "244698150"
+  microos_arm_snapshot_id = "244698267"
 
   ### ADVANCED - Custom helm values for packages above (search _values if you want to located where those are mentioned upper in this file)
   # ⚠️ Inside the _values variable below are examples, up to you to find out the best helm values possible, we do not provide support for customized helm values.


### PR DESCRIPTION
Update kube.tf to build k3s nodes with snapshot images as per #13.