### PR TITLE
Fix: helm values for cilium and cert-manager.

### DIFF
--- a/infra/cluster/dev/helm/helmfile.yaml.gotmpl
+++ b/infra/cluster/dev/helm/helmfile.yaml.gotmpl
@@ -1,23 +1,10 @@
 repositories:
-  - name: jetstack
-    url: https://charts.jetstack.io
   - name: prometheus-community
     url: https://prometheus-community.github.io/helm-charts
   - name: grafana
     url: https://grafana.github.io/helm-charts
 
 releases:
-  - name: cert-manager
-    namespace: cert-manager
-    createNamespace: true
-    chart: jetstack/cert-manager
-    version: v1.15.2
-    values:
-      - values/cert-manager.yaml
-    set:
-      - name: installCRDs
-        value: true
-
   - name: prometheus
     namespace: o11y
     createNamespace: true

--- a/infra/cluster/dev/kube.tf
+++ b/infra/cluster/dev/kube.tf
@@ -874,12 +874,12 @@ module "kube-hetzner" {
   # Cilium, all Cilium helm values can be found at https://github.com/cilium/cilium/blob/master/install/kubernetes/cilium/values.yaml
   # Be careful when maintaining your own cilium_values, as the choice of available settings depends on the Cilium version used. See also the cilium_version setting to fix a specific version.
   # The following is an example, please note that the current indentation inside the EOT is important.
-  cilium_values = file("../../helm/cilium.values.yaml")
+  cilium_values = file("../helm_values/cilium.values.yaml")
 
   # Cert manager, all cert-manager helm values can be found at https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml
   # The following is an example, please note that the current indentation inside the EOT is important.
   # For cert-manager versions < v1.15.0, you need to set installCRDs: true instead of crds.enabled and crds.keep.
-  cert_manager_values = file("../../helm/cert-manager.values.yaml")
+  cert_manager_values = file("../helm_values/cert-manager.values.yaml")
 
   # csi-driver-smb, all csi-driver-smb helm values can be found at https://github.com/kubernetes-csi/csi-driver-smb/blob/master/charts/latest/csi-driver-smb/values.yaml
   # The following is an example, please note that the current indentation inside the EOT is important.


### PR DESCRIPTION
- helm_values is the dirname for cilium and cert-manager helm chart values.
- cert-manager is already installed by kube-hetzner module so its redundant in the helmfile.